### PR TITLE
Upgrade to brick/reflection ^0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.3",
-        "brick/reflection": "^0.3",
+        "brick/reflection": "^0.4",
         "doctrine/doctrine-bundle": "^1.9 || ^2.0",
         "dragonmantank/cron-expression": "^2.2",
         "symfony/config": "^4.4 || ^5.0",

--- a/src/Form/TypeGuesser/CronExpressionTypeGuesser.php
+++ b/src/Form/TypeGuesser/CronExpressionTypeGuesser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Setono\CronExpressionBundle\Form\TypeGuesser;
 
-use Brick\Reflection\ImportResolver;
 use Brick\Reflection\ReflectionTools;
 use Cron\CronExpression;
 use ReflectionClass;
@@ -37,18 +36,8 @@ final class CronExpressionTypeGuesser implements FormTypeGuesserInterface
         $reflectionTools = new ReflectionTools();
         $propertyTypes = $reflectionTools->getPropertyTypes($reflectionProperty);
 
-        if (count($propertyTypes) === 0) {
-            return null;
-        }
-
-        $resolver = new ImportResolver($reflectionClass);
-
-        foreach ($propertyTypes as $propertyType) {
-            $fqn = $resolver->resolve($propertyType);
-
-            if (CronExpression::class === $fqn) {
-                return new TypeGuess(CronExpressionType::class, [], Guess::VERY_HIGH_CONFIDENCE);
-            }
+        if (in_array(CronExpression::class, $propertyTypes, true)) {
+            return new TypeGuess(CronExpressionType::class, [], Guess::VERY_HIGH_CONFIDENCE);
         }
 
         return null;


### PR DESCRIPTION
Hi, thanks for using brick/reflection! I've just released version [0.4.0](https://github.com/brick/reflection/releases/tag/0.4.0).

`ReflectionTools::getPropertyTypes()` now always returns FQCNs, this PR updates your code to use the new version!