### PR TITLE
Add different FormType options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
         "symfony/form": "^4.4 || ^5.4 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "symfony/options-resolver": "^4.4 || ^5.4 || ^6.0",
         "symfony/validator": "^4.4 || ^5.4 || ^6.0",
         "webmozart/assert": "^1.10"
     },

--- a/src/Form/DataTransformer/CronExpressionToStringPartsTransformer.php
+++ b/src/Form/DataTransformer/CronExpressionToStringPartsTransformer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Form\DataTransformer;
+
+use Cron\CronExpression;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Webmozart\Assert\Assert;
+
+final class CronExpressionToStringPartsTransformer implements DataTransformerInterface
+{
+    /**
+     * @param mixed $value
+     */
+    public function transform($value): array
+    {
+        if (null === $value) {
+            return [
+                'minutes' => '*',
+                'hours' => '*',
+                'days' => '*',
+                'months' => '*',
+                'weekdays' => '*',
+            ];
+        }
+
+        if (!$value instanceof CronExpression) {
+            throw new TransformationFailedException('Expected an instance of ' . CronExpression::class);
+        }
+
+        return [
+            'minutes' => (string) $value->getExpression((string) CronExpression::MINUTE),
+            'hours' => (string) $value->getExpression((string) CronExpression::HOUR),
+            'days' => (string) $value->getExpression((string) CronExpression::DAY),
+            'months' => (string) $value->getExpression((string) CronExpression::MONTH),
+            'weekdays' => (string) $value->getExpression((string) CronExpression::WEEKDAY),
+        ];
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function reverseTransform($value): CronExpression
+    {
+        $exception = new TransformationFailedException('Expected an instance of array{minutes: string, hours: string, days: string, months: string, weekdays: string}');
+
+        $cronExpression = CronExpression::factory('* * * * *');
+
+        if (null === $value) {
+            return $cronExpression;
+        }
+
+        if (!is_array($value)) {
+            throw $exception;
+        }
+
+        if (!isset($value['minutes'], $value['hours'], $value['days'], $value['months'], $value['weekdays'])) {
+            throw $exception;
+        }
+
+        try {
+            Assert::allString($value);
+        } catch (\InvalidArgumentException $e) {
+            throw $exception;
+        }
+
+        try {
+            $cronExpression
+                ->setPart(CronExpression::MINUTE, $value['minutes'])
+                ->setPart(CronExpression::HOUR, $value['hours'])
+                ->setPart(CronExpression::DAY, $value['days'])
+                ->setPart(CronExpression::MONTH, $value['months'])
+                ->setPart(CronExpression::WEEKDAY, $value['weekdays'])
+            ;
+        } catch (\InvalidArgumentException $e) {
+            throw $exception;
+        }
+
+        return $cronExpression;
+    }
+}

--- a/src/Form/DataTransformer/CronExpressionToStringTransformer.php
+++ b/src/Form/DataTransformer/CronExpressionToStringTransformer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Form\DataTransformer;
+
+use Cron\CronExpression;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+final class CronExpressionToStringTransformer implements DataTransformerInterface
+{
+    /**
+     * @param mixed $value
+     */
+    public function transform($value): ?string
+    {
+        if (null === $value) {
+            return '* * * * *';
+        }
+
+        if (!$value instanceof CronExpression) {
+            throw new TransformationFailedException('Expected an instance of ' . CronExpression::class);
+        }
+
+        return $value->getExpression();
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function reverseTransform($value): CronExpression
+    {
+        if (null === $value || '' === $value) {
+            return CronExpression::factory('* * * * *');
+        }
+
+        if (!is_string($value)) {
+            throw new TransformationFailedException('Expected an instance of string');
+        }
+
+        return CronExpression::factory($value);
+    }
+}

--- a/src/Form/Type/CronExpressionType.php
+++ b/src/Form/Type/CronExpressionType.php
@@ -4,43 +4,125 @@ declare(strict_types=1);
 
 namespace Setono\CronExpressionBundle\Form\Type;
 
+use Cron\CronExpression;
+use Cron\FieldFactory;
 use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToPartsTransformer;
+use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToStringPartsTransformer;
+use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToStringTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class CronExpressionType extends AbstractType
 {
+    protected FieldFactory $fieldFactory;
+
+    public function __construct()
+    {
+        $this->fieldFactory = new FieldFactory();
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->addViewTransformer(new CronExpressionToPartsTransformer())
-            ->add('minutes', ChoiceType::class, [
-                'choices' => range(0, 59),
-                'multiple' => true,
-                'required' => false,
-            ])
-            ->add('hours', ChoiceType::class, [
-                'choices' => range(0, 23),
-                'multiple' => true,
-                'required' => false,
-            ])
-            ->add('days', ChoiceType::class, [
-                'choices' => $this->oneIndexedRange(31),
-                'multiple' => true,
-                'required' => false,
-            ])
-            ->add('months', ChoiceType::class, [
-                'choices' => $this->oneIndexedRange(12),
-                'multiple' => true,
-                'required' => false,
-            ])
-            ->add('weekdays', ChoiceType::class, [
-                'choices' => $this->oneIndexedRange(7),
-                'multiple' => true,
-                'required' => false,
-            ])
-        ;
+        if ('single_text' === $options['widget']) {
+            $builder->addViewTransformer(new CronExpressionToStringTransformer());
+        } elseif ('text' === $options['widget']) {
+            $builder
+                ->addViewTransformer(new CronExpressionToStringPartsTransformer())
+                ->add('minutes', TextType::class, [
+                    'required' => true,
+                    'empty_data' => '*',
+                    'constraints' => [
+                        $this->buildCallback(CronExpression::MINUTE),
+                    ],
+                ])
+                ->add('hours', TextType::class, [
+                    'required' => true,
+                    'empty_data' => '*',
+                    'constraints' => [
+                        $this->buildCallback(CronExpression::HOUR),
+                    ],
+                ])
+                ->add('days', TextType::class, [
+                    'required' => true,
+                    'empty_data' => '*',
+                    'constraints' => [
+                        $this->buildCallback(CronExpression::DAY),
+                    ],
+                ])
+                ->add('months', TextType::class, [
+                    'required' => true,
+                    'empty_data' => '*',
+                    'constraints' => [
+                        $this->buildCallback(CronExpression::MONTH),
+                    ],
+                ])
+                ->add('weekdays', TextType::class, [
+                    'required' => true,
+                    'empty_data' => '*',
+                    'constraints' => [
+                        $this->buildCallback(CronExpression::WEEKDAY),
+                    ],
+                ])
+            ;
+        } else {
+            $builder
+                ->addViewTransformer(new CronExpressionToPartsTransformer())
+                ->add('minutes', ChoiceType::class, [
+                    'choices' => range(0, 59),
+                    'multiple' => true,
+                    'required' => false,
+                ])
+                ->add('hours', ChoiceType::class, [
+                    'choices' => range(0, 23),
+                    'multiple' => true,
+                    'required' => false,
+                ])
+                ->add('days', ChoiceType::class, [
+                    'choices' => $this->oneIndexedRange(31),
+                    'multiple' => true,
+                    'required' => false,
+                ])
+                ->add('months', ChoiceType::class, [
+                    'choices' => $this->oneIndexedRange(12),
+                    'multiple' => true,
+                    'required' => false,
+                ])
+                ->add('weekdays', ChoiceType::class, [
+                    'choices' => $this->oneIndexedRange(7),
+                    'multiple' => true,
+                    'required' => false,
+                ])
+            ;
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $compound = function (Options $options): bool {
+            return 'single_text' !== $options['widget'];
+        };
+
+        $resolver->setDefaults([
+            'widget' => null,
+            'data_class' => null,
+            'compound' => $compound,
+//            'empty_data' => function (Options $options) {
+//                return $options['compound'] ? [] : '';
+//            },
+        ]);
+
+        $resolver->setAllowedValues('widget', [
+            null, // default, don't overwrite options
+            'single_text',
+            'text',
+            'choice',
+        ]);
     }
 
     public function getBlockPrefix(): string
@@ -58,5 +140,24 @@ final class CronExpressionType extends AbstractType
         unset($arr[0]);
 
         return $arr;
+    }
+
+    protected function buildCallback(int $payload): Callback
+    {
+        // helper function for Symfony 4.4
+        return new Callback([
+            'callback' => [$this, 'validateCronField'],
+            'payload' => $payload,
+        ]);
+    }
+
+    public function validateCronField(?string $value, ExecutionContextInterface $context, int $payload): void
+    {
+        if (null === $value) {
+            return;
+        }
+        if (!$this->fieldFactory->getField($payload)->validate($value)) {
+            $context->addViolation('{{value}} is not a valid cron part', ['value' => $value]);
+        }
     }
 }

--- a/tests/Form/DataTransformer/ToPartsTest.php
+++ b/tests/Form/DataTransformer/ToPartsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\DataTransformer;
+
+use Cron\CronExpression;
+use PHPUnit\Framework\TestCase;
+use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToPartsTransformer;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class ToPartsTest extends TestCase
+{
+    public function testNullReverseTransform(): void
+    {
+        $this->expectedReverseTransform(null, '* * * * *');
+    }
+
+    public function testArrayReverseTransform(): void
+    {
+        $this->expectedReverseTransform([
+            'minutes' => ['0'],
+            'hours' => ['12'],
+            'days' => ['1'],
+            'months' => ['6'],
+            'weekdays' => ['3'],
+        ], '0 12 1 6 3');
+    }
+
+    public function testWrongClassInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform(new stdClass());
+    }
+
+    public function testMissingKeyInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform([
+            'minutes' => ['0'],
+        ]);
+    }
+
+    public function testFaultyKeyTypeInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform([
+            'minutes' => '0',
+            'hours' => ['12'],
+            'days' => ['1'],
+            'months' => ['6'],
+            'weekdays' => ['3'],
+        ]);
+    }
+
+    public function testFaultyKeyRangeInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform([
+            'minutes' => ['61'],
+            'hours' => ['12'],
+            'days' => ['1'],
+            'months' => ['6'],
+            'weekdays' => ['3'],
+        ]);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function invalidReverseTransform($value): void
+    {
+        $transformer = new CronExpressionToPartsTransformer();
+        $this->expectException(TransformationFailedException::class);
+        $transformer->reverseTransform($value);
+    }
+
+    /**
+     * @param mixed $input
+     */
+    protected function expectedReverseTransform($input, string $expected): void
+    {
+        $transformer = new CronExpressionToPartsTransformer();
+        $value = $transformer->reverseTransform($input);
+
+        $this->assertInstanceOf(CronExpression::class, $value);
+        $this->assertSame($expected, $value->getExpression());
+    }
+}

--- a/tests/Form/DataTransformer/ToStringPartsTest.php
+++ b/tests/Form/DataTransformer/ToStringPartsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\DataTransformer;
+
+use Cron\CronExpression;
+use PHPUnit\Framework\TestCase;
+use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToStringPartsTransformer;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class ToStringPartsTest extends TestCase
+{
+    public function testNullReverseTransform(): void
+    {
+        $this->expectedReverseTransform(null, '* * * * *');
+    }
+
+    public function testArrayReverseTransform(): void
+    {
+        $this->expectedReverseTransform([
+            'minutes' => '0',
+            'hours' => '12',
+            'days' => '1',
+            'months' => '6',
+            'weekdays' => '3',
+        ], '0 12 1 6 3');
+    }
+
+    public function testWrongClassInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform(new stdClass());
+    }
+
+    public function testMissingKeyInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform([
+            'minutes' => '*',
+        ]);
+    }
+
+    public function testFaultyKeyInvalidReverseTransform(): void
+    {
+        $this->invalidReverseTransform([
+            'minutes' => 0,
+            'hours' => '12',
+            'days' => '1',
+            'months' => '6',
+            'weekdays' => '3',
+        ]);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    protected function invalidReverseTransform($value): void
+    {
+        $transformer = new CronExpressionToStringPartsTransformer();
+        $this->expectException(TransformationFailedException::class);
+        $transformer->reverseTransform($value);
+    }
+
+    /**
+     * @param mixed $input
+     */
+    protected function expectedReverseTransform($input, string $expected): void
+    {
+        $transformer = new CronExpressionToStringPartsTransformer();
+        $value = $transformer->reverseTransform($input);
+
+        $this->assertInstanceOf(CronExpression::class, $value);
+        $this->assertSame($expected, $value->getExpression());
+    }
+}

--- a/tests/Form/DataTransformer/ToStringTest.php
+++ b/tests/Form/DataTransformer/ToStringTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Setono\CronExpressionBundle\Form\DataTransformer\CronExpressionToStringTransformer;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+class ToStringTest extends TestCase
+{
+    public function testInvalidReverseTransform(): void
+    {
+        $transformer = new CronExpressionToStringTransformer();
+        $this->expectException(TransformationFailedException::class);
+        $transformer->reverseTransform(new stdClass());
+    }
+}

--- a/tests/Form/Type/CronExpressionTypeCallbackTest.php
+++ b/tests/Form/Type/CronExpressionTypeCallbackTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\Type;
+
+use Cron\CronExpression;
+use PHPUnit\Framework\MockObject\Rule\InvokedCount as InvokedCountMatcher;
+use PHPUnit\Framework\TestCase;
+use Setono\CronExpressionBundle\Form\Type\CronExpressionType;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+class CronExpressionTypeCallbackTest extends TestCase
+{
+    public function testNullNoViolation(): void
+    {
+        $this->callValidateCronField(null, $this->never());
+    }
+
+    public function testValidNoViolation(): void
+    {
+        $this->callValidateCronField('59', $this->never());
+    }
+
+    public function testViolationAdded(): void
+    {
+        $this->callValidateCronField('61', $this->once());
+    }
+
+    protected function callValidateCronField(?string $value, InvokedCountMatcher $counter): void
+    {
+        $mock = $this->createMock(ExecutionContextInterface::class);
+        $mock->expects($counter)->method('addViolation')
+            ->with('{{value}} is not a valid cron part', ['value' => $value]);
+
+        $type = new CronExpressionType();
+        $type->validateCronField($value, $mock, CronExpression::MINUTE);
+    }
+}

--- a/tests/Form/Type/CronExpressionTypeStringTest.php
+++ b/tests/Form/Type/CronExpressionTypeStringTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\Type;
+
+use Cron\CronExpression;
+use Setono\CronExpressionBundle\Form\Type\CronExpressionType;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class CronExpressionTypeStringTest extends TypeTestCase
+{
+    /**
+     * @test
+     */
+    public function submitWithAllSet(): void
+    {
+        $this->_submit('0 12 1 6 3', '0 12 1 6 3');
+    }
+
+    /**
+     * @test
+     */
+    public function submitMultipleMinutes(): void
+    {
+        $this->_submit('0,13 12 1 6 3', '0,13 12 1 6 3');
+    }
+
+    /**
+     * @test
+     */
+    public function submitMinutesOnly(): void
+    {
+        $this->_submit('0 * * * *', '0 * * * *');
+    }
+
+    /**
+     * @test
+     */
+    public function submitEmpty(): void
+    {
+        $this->_submit(null, '* * * * *');
+    }
+
+    private function _submit(?string $formData, string $expected): void
+    {
+        $form = $this->factory->create(CronExpressionType::class, null, [
+            'widget' => 'single_text',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        /** @var CronExpression $cronExpression */
+        $cronExpression = $form->getData();
+
+        $this->assertInstanceOf(CronExpression::class, $cronExpression);
+        $this->assertSame($expected, $cronExpression->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    public function submitFaultyEmpty(): void
+    {
+        $this->_submitFaultyData([]);
+    }
+
+    /**
+     * @test
+     */
+    public function submitFaultyArray(): void
+    {
+        $this->_submitFaultyData([
+            'foo' => 'bar',
+        ]);
+    }
+
+    /**
+     * @param string|array|null $formData
+     */
+    private function _submitFaultyData($formData): void
+    {
+        $form = $this->factory->create(CronExpressionType::class, null, [
+            'widget' => 'single_text',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertFalse($form->isSynchronized());
+    }
+
+    /**
+     * @test
+     */
+    public function createWithFaultyData(): void
+    {
+        $data = new stdClass();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->factory->create(CronExpressionType::class, $data, [
+            'widget' => 'single_text',
+        ]);
+    }
+}

--- a/tests/Form/Type/CronExpressionTypeTest.php
+++ b/tests/Form/Type/CronExpressionTypeTest.php
@@ -6,6 +6,8 @@ namespace Setono\CronExpressionBundle\Tests\Form\Type;
 
 use Cron\CronExpression;
 use Setono\CronExpressionBundle\Form\Type\CronExpressionType;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Test\TypeTestCase;
 
 class CronExpressionTypeTest extends TypeTestCase
@@ -77,5 +79,16 @@ class CronExpressionTypeTest extends TypeTestCase
 
         $this->assertInstanceOf(CronExpression::class, $cronExpression);
         $this->assertSame($expected, $cronExpression->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    public function createWithFaultyData(): void
+    {
+        $data = new stdClass();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->factory->create(CronExpressionType::class, $data);
     }
 }

--- a/tests/Form/Type/CronExpressionTypeTextTest.php
+++ b/tests/Form/Type/CronExpressionTypeTextTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Form\Type;
+
+use Cron\CronExpression;
+use Setono\CronExpressionBundle\Form\Type\CronExpressionType;
+use stdClass;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Test\Traits\ValidatorExtensionTrait;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+class CronExpressionTypeTextTest extends TypeTestCase
+{
+    use ValidatorExtensionTrait;
+
+    /**
+     * @test
+     */
+    public function submitWithAllSet(): void
+    {
+        $this->_submit([
+            'minutes' => '0',
+            'hours' => '12',
+            'days' => '1',
+            'months' => '6',
+            'weekdays' => '3',
+        ], '0 12 1 6 3');
+    }
+
+    /**
+     * @test
+     */
+    public function submitMultipleMinutes(): void
+    {
+        $this->_submit([
+            'minutes' => '0,13',
+            'hours' => '12',
+            'days' => '1',
+            'months' => '6',
+            'weekdays' => '3',
+        ], '0,13 12 1 6 3');
+    }
+
+    /**
+     * @test
+     */
+    public function submitMinutesOnly(): void
+    {
+        $this->_submit([
+            'minutes' => '0',
+        ], '0 * * * *');
+    }
+
+    /**
+     * @test
+     */
+    public function submitEmpty(): void
+    {
+        $this->_submit([], '* * * * *');
+    }
+
+    private function _submit(array $formData, string $expected): void
+    {
+        $form = $this->factory->create(CronExpressionType::class, null, [
+            'widget' => 'text',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue($form->isSynchronized());
+
+        $view = $form->createView();
+        $children = $view->children;
+
+        foreach (array_keys($formData) as $key) {
+            $this->assertArrayHasKey($key, $children);
+        }
+
+        /** @var CronExpression $cronExpression */
+        $cronExpression = $form->getData();
+
+        $this->assertInstanceOf(CronExpression::class, $cronExpression);
+        $this->assertSame($expected, $cronExpression->getExpression());
+    }
+
+    /**
+     * @test
+     */
+    public function submitFaultyMinutesOnly(): void
+    {
+        $this->_submitFaultyData([
+            'minutes' => '61',
+        ]);
+    }
+
+    /**
+     * @param string|array|null $formData
+     */
+    private function _submitFaultyData($formData): void
+    {
+        $form = $this->factory->create(CronExpressionType::class, null, [
+            'widget' => 'text',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertFalse($form->isSynchronized());
+    }
+
+    /**
+     * @test
+     */
+    public function createWithFaultyData(): void
+    {
+        $data = new stdClass();
+
+        $this->expectException(TransformationFailedException::class);
+        $this->factory->create(CronExpressionType::class, $data, [
+            'widget' => 'text',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function submitChild(): void
+    {
+        $this->_submitWithChild([
+            'minutes' => '0',
+        ], '0 * * * *');
+    }
+
+    /**
+     * @test
+     */
+    public function submitNull(): void
+    {
+        $this->_submitWithChild(null, '* * * * *');
+    }
+
+    /**
+     * @param mixed $formData
+     */
+    public function _submitWithChild($formData, string $expected): void
+    {
+        $builder = $this->factory->createBuilder();
+        $builder->add('cron', CronExpressionType::class, [
+            'widget' => 'text',
+        ]);
+        $form = $builder->getForm();
+        $form->submit(['cron' => $formData]);
+
+        /** @var array $data */
+        $data = $form->getData();
+        /** @var CronExpression $cronExpression */
+        $cronExpression = $data['cron'];
+
+        $this->assertInstanceOf(CronExpression::class, $cronExpression);
+        $this->assertSame($expected, $cronExpression->getExpression());
+    }
+}

--- a/tests/Validator/FormCallbackTest.php
+++ b/tests/Validator/FormCallbackTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\CronExpressionBundle\Tests\Validator;
+
+use Cron\CronExpression;
+use Setono\CronExpressionBundle\Form\Type\CronExpressionType;
+use Symfony\Component\Validator\Constraints\Callback;
+use Symfony\Component\Validator\Constraints\CallbackValidator;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class FormCallbackTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator(): CallbackValidator
+    {
+        return new CallbackValidator();
+    }
+
+    public function testNullIsValid(): void
+    {
+        $this->validator->validate(null, $this->createConstraint(CronExpression::MINUTE));
+        $this->assertNoViolation();
+    }
+
+    public function testValidIsValid(): void
+    {
+        $this->validator->validate("0", $this->createConstraint(CronExpression::MINUTE));
+        $this->assertNoViolation();
+    }
+
+    public function testOutOfRangeIsNotValid(): void
+    {
+        $value = "61";
+        $this->validator->validate($value, $this->createConstraint(CronExpression::MINUTE));
+        /** @psalm-suppress InternalMethod,MixedMethodCall */
+        $this->buildViolation('{{value}} is not a valid cron part')->setParameter('value', $value)->assertRaised();
+    }
+
+    protected function createConstraint($payload): Callback
+    {
+        // helper function for Symfony 4.4
+        return new Callback([
+            'callback' => [new CronExpressionType(), 'validateCronField'],
+            'payload' => $payload,
+        ]);
+    }
+}

--- a/tests/Validator/FormCallbackTest.php
+++ b/tests/Validator/FormCallbackTest.php
@@ -25,19 +25,19 @@ class FormCallbackTest extends ConstraintValidatorTestCase
 
     public function testValidIsValid(): void
     {
-        $this->validator->validate("0", $this->createConstraint(CronExpression::MINUTE));
+        $this->validator->validate('0', $this->createConstraint(CronExpression::MINUTE));
         $this->assertNoViolation();
     }
 
     public function testOutOfRangeIsNotValid(): void
     {
-        $value = "61";
+        $value = '61';
         $this->validator->validate($value, $this->createConstraint(CronExpression::MINUTE));
         /** @psalm-suppress InternalMethod,MixedMethodCall */
         $this->buildViolation('{{value}} is not a valid cron part')->setParameter('value', $value)->assertRaised();
     }
 
-    protected function createConstraint($payload): Callback
+    protected function createConstraint(int $payload): Callback
     {
         // helper function for Symfony 4.4
         return new Callback([


### PR DESCRIPTION
This adds 2 new widget styles for the FormType:

- single_text is a simple text input field (is this still in draft)
- text is a text input field per section

Closes #24
Closes #26
both of them are for using "4-7/2" and other complicated values.