### PR TITLE
CronExpressionType: new Exceptions for dbal4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "doctrine/dbal": "^3.4",
+        "doctrine/dbal": "^3.4 || ^4.0",
         "doctrine/doctrine-bundle": "^1.9 || ^2.0",
         "dragonmantank/cron-expression": "^2.2 || ^3.0",
         "symfony/config": "^5.4 || ^6.0",

--- a/src/Doctrine/DBAL/Types/CronExpressionType.php
+++ b/src/Doctrine/DBAL/Types/CronExpressionType.php
@@ -32,9 +32,10 @@ final class CronExpressionType extends Type
         if (!is_string($value)) {
             if (class_exists(InvalidType::class)) {
                 throw InvalidType::new($value, CronExpression::class, ['string']);
-            } else {
+            } else if (method_exists(ConversionException::class, "conversionFailedInvalidType")) {
                 throw ConversionException::conversionFailedInvalidType($value, CronExpression::class, ['string']);
             }
+            return null;
         }
 
         if ('' === $value) {
@@ -46,9 +47,10 @@ final class CronExpressionType extends Type
         } catch (\Throwable $e) {
             if (class_exists(ValueNotConvertible::class)) {
                 throw ValueNotConvertible::new($value, CronExpression::class, null, $e);
-            } else {
+            } else if (method_exists(ConversionException::class, "conversionFailed")) {
                 throw ConversionException::conversionFailed($value, CronExpression::class, $e);
             }
+            return null;
         }
     }
 

--- a/src/Doctrine/DBAL/Types/CronExpressionType.php
+++ b/src/Doctrine/DBAL/Types/CronExpressionType.php
@@ -7,6 +7,8 @@ namespace Setono\CronExpressionBundle\Doctrine\DBAL\Types;
 use Cron\CronExpression;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use Doctrine\DBAL\Types\Type;
 
 final class CronExpressionType extends Type
@@ -28,7 +30,11 @@ final class CronExpressionType extends Type
         }
 
         if (!is_string($value)) {
-            throw ConversionException::conversionFailedInvalidType($value, CronExpression::class, ['string']);
+            if (class_exists(InvalidType::class)) {
+                throw InvalidType::new($value, CronExpression::class, ['string']);
+            } else {
+                throw ConversionException::conversionFailedInvalidType($value, CronExpression::class, ['string']);
+            }
         }
 
         if ('' === $value) {
@@ -38,7 +44,11 @@ final class CronExpressionType extends Type
         try {
             return CronExpression::factory($value);
         } catch (\Throwable $e) {
-            throw ConversionException::conversionFailed($value, CronExpression::class, $e);
+            if (class_exists(ValueNotConvertible::class)) {
+                throw ValueNotConvertible::new($value, CronExpression::class, null, $e);
+            } else {
+                throw ConversionException::conversionFailed($value, CronExpression::class, $e);
+            }
         }
     }
 

--- a/src/Doctrine/DBAL/Types/CronExpressionType.php
+++ b/src/Doctrine/DBAL/Types/CronExpressionType.php
@@ -32,10 +32,12 @@ final class CronExpressionType extends Type
         if (!is_string($value)) {
             if (class_exists(InvalidType::class)) {
                 throw InvalidType::new($value, CronExpression::class, ['string']);
-            } else if (method_exists(ConversionException::class, "conversionFailedInvalidType")) {
+            } else {
+                /**
+                 * @psalm-suppress UndefinedMethod
+                 */
                 throw ConversionException::conversionFailedInvalidType($value, CronExpression::class, ['string']);
             }
-            return null;
         }
 
         if ('' === $value) {
@@ -47,10 +49,12 @@ final class CronExpressionType extends Type
         } catch (\Throwable $e) {
             if (class_exists(ValueNotConvertible::class)) {
                 throw ValueNotConvertible::new($value, CronExpression::class, null, $e);
-            } else if (method_exists(ConversionException::class, "conversionFailed")) {
+            } else {
+                /**
+                 * @psalm-suppress UndefinedMethod
+                 */
                 throw ConversionException::conversionFailed($value, CronExpression::class, $e);
             }
-            return null;
         }
     }
 

--- a/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
@@ -7,6 +7,8 @@ namespace Setono\CronExpressionBundle\Tests\Doctrine\DBAL\Types;
 use Cron\CronExpression;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidType;
+use Doctrine\DBAL\Types\Exception\ValueNotConvertible;
 use Doctrine\DBAL\Types\Type;
 use PHPUnit\Framework\TestCase;
 use Setono\CronExpressionBundle\Doctrine\DBAL\Types\CronExpressionType;
@@ -78,6 +80,9 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyTypeToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
+        if (class_exists(InvalidType::class)) {
+            self::expectException(InvalidType::class);
+        }
 
         $this->getType()->convertToPHPValue(new stdClass(), $this->getPlatform());
     }
@@ -88,6 +93,9 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyStringToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
+        if (class_exists(ValueNotConvertible::class)) {
+            self::expectException(ValueNotConvertible::class);
+        }
 
         $this->getType()->convertToPHPValue('@never', $this->getPlatform());
     }

--- a/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
@@ -80,7 +80,7 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyTypeToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
-        if (class_exists(InvalidType::class)) {
+        if (class_exists(InvalidType::class) and is_a(InvalidType::class, \Throwable::class, true)) {
             self::expectException(InvalidType::class);
         }
 
@@ -93,7 +93,7 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyStringToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
-        if (class_exists(ValueNotConvertible::class)) {
+        if (class_exists(ValueNotConvertible::class) and is_a(ValueNotConvertible::class, \Throwable::class, true)) {
             self::expectException(ValueNotConvertible::class);
         }
 

--- a/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/CronExpressionTypeTest.php
@@ -80,7 +80,10 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyTypeToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
-        if (class_exists(InvalidType::class) and is_a(InvalidType::class, \Throwable::class, true)) {
+        if (class_exists(InvalidType::class)) {
+            /**
+             * @psalm-suppress InvalidArgument
+             */
             self::expectException(InvalidType::class);
         }
 
@@ -93,7 +96,10 @@ final class CronExpressionTypeTest extends TestCase
     public function convertFaultyStringToPhpThrowsException(): void
     {
         self::expectException(ConversionException::class);
-        if (class_exists(ValueNotConvertible::class) and is_a(ValueNotConvertible::class, \Throwable::class, true)) {
+        if (class_exists(ValueNotConvertible::class)) {
+            /**
+             * @psalm-suppress InvalidArgument
+             */
             self::expectException(ValueNotConvertible::class);
         }
 


### PR DESCRIPTION
Closes #42

I'm unsure about if the second exception is more `InvalidFormat`, but these one wants an `$expectedFormat` and I don't think that works for this