### PR TITLE
Add old symfony/property-info to codecov

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -242,6 +242,6 @@ jobs:
                 run: "vendor/bin/phpunit --coverage-clover=.build/logs/clover.xml"
 
             -   name: "Send code coverage report to Codecov.io"
-                env:
-                    CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
-                run: "bash <(curl -s https://codecov.io/bash)"
+                uses: "codecov/codecov-action@v5"
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,6 +214,9 @@ jobs:
                 dependencies:
                     - "highest"
 
+                symfony:
+                    - "^6.4" #old symfony/property-info
+                    - "^8.0"
         steps:
             -   name: "Checkout"
                 uses: "actions/checkout@v4"
@@ -230,6 +233,8 @@ jobs:
 
             -   name: "Install composer dependencies"
                 uses: "ramsey/composer-install@v3"
+                env:
+                    SYMFONY_REQUIRE: "${{ matrix.symfony }}"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -227,6 +227,7 @@ jobs:
                     coverage: "pcov"
                     extensions: "${{ env.PHP_EXTENSIONS }}"
                     php-version: "${{ matrix.php-version }}"
+                    tools: "flex"
 
             -   name: "Set up problem matchers for phpunit/phpunit"
                 run: "echo \"::add-matcher::${{ runner.tool_cache }}/phpunit.json\""


### PR DESCRIPTION
This should get the Codecov back to 100% after https://github.com/Setono/CronExpressionBundle/commit/e3c32a289e317cc5dff1dc98575a20a6d0697954 added code paths for type-info